### PR TITLE
Adding Enabled Field and Remove Schedule Config

### DIFF
--- a/discourse/km/connector/discourse_categoriesconnector.json
+++ b/discourse/km/connector/discourse_categoriesconnector.json
@@ -7,7 +7,8 @@
     "sourceConfig": {
       "apiPushConfig": {
         "app": "58905",
-        "dataFormat": "JSON"
+        "dataFormat": "JSON",
+        "enabled": true
       }
     },
     "baseSelector": {
@@ -97,9 +98,5 @@
         }
       ]
     }
-  ],
-  "scheduleConfig": {
-    "useSourceSchedule": true,
-    "runMode": "DEFAULT"
-  }
+  ]
 }

--- a/discourse/km/connector/discourse_topicsconnector.json
+++ b/discourse/km/connector/discourse_topicsconnector.json
@@ -7,7 +7,8 @@
     "sourceConfig": {
       "apiPushConfig": {
         "app": "58905",
-        "dataFormat": "JSON"
+        "dataFormat": "JSON",
+        "enabled": true
       }
     },
     "baseSelector": {
@@ -470,9 +471,5 @@
       "header": "Views",
       "subfieldPath": []
     }
-  ],
-  "scheduleConfig": {
-    "useSourceSchedule": true,
-    "runMode": "DEFAULT"
-  }
+  ]
 }


### PR DESCRIPTION
Schedule Configurations will soon be removed from all push connectors
with added validation preventing it. Adding enabled flag which will
be used when pushing data - the enabled flag uses the boolean from
use source schedule
